### PR TITLE
Use `huggingface_hub.InferenceClient` instead of `openai.OpenAI` to call Sambanova

### DIFF
--- a/demo/hello_computer/app.py
+++ b/demo/hello_computer/app.py
@@ -4,8 +4,8 @@ import os
 from pathlib import Path
 
 import gradio as gr
+import huggingface_hub
 import numpy as np
-import openai
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, StreamingResponse
@@ -24,9 +24,9 @@ load_dotenv()
 curr_dir = Path(__file__).parent
 
 
-client = openai.OpenAI(
+client = huggingface_hub.InferenceClient(
     api_key=os.environ.get("SAMBANOVA_API_KEY"),
-    base_url="https://api.sambanova.ai/v1",
+    provider="sambanova",
 )
 model = get_stt_model()
 
@@ -49,7 +49,7 @@ def response(
     conversation_state.append({"role": "user", "content": text})
 
     request = client.chat.completions.create(
-        model="Meta-Llama-3.2-3B-Instruct",
+        model="meta-llama/Llama-3.2-3B-Instruct",
         messages=conversation_state,  # type: ignore
         temperature=0.1,
         top_p=0.1,

--- a/demo/hello_computer/requirements.txt
+++ b/demo/hello_computer/requirements.txt
@@ -1,4 +1,4 @@
 fastrtc[stopword]
 python-dotenv
-openai
+huggingface_hub>=0.29.0
 twilio

--- a/demo/talk_to_sambanova/app.py
+++ b/demo/talk_to_sambanova/app.py
@@ -4,8 +4,8 @@ import os
 from pathlib import Path
 
 import gradio as gr
+import huggingface_hub
 import numpy as np
-import openai
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, StreamingResponse
@@ -13,7 +13,6 @@ from fastrtc import (
     AdditionalOutputs,
     ReplyOnPause,
     Stream,
-    WebRTCError,
     get_stt_model,
     get_twilio_turn_credentials,
 )
@@ -25,9 +24,9 @@ load_dotenv()
 curr_dir = Path(__file__).parent
 
 
-client = openai.OpenAI(
+client = huggingface_hub.InferenceClient(
     api_key=os.environ.get("SAMBANOVA_API_KEY"),
-    base_url="https://api.sambanova.ai/v1",
+    provider="sambanova",
 )
 stt_model = get_stt_model()
 
@@ -49,10 +48,8 @@ def response(
 
     conversation_state.append({"role": "user", "content": text})
 
-    raise WebRTCError("test")
-
     request = client.chat.completions.create(
-        model="Meta-Llama-3.2-3B-Instruct",
+        model="meta-llama/Llama-3.2-3B-Instruct",
         messages=conversation_state,  # type: ignore
         temperature=0.1,
         top_p=0.1,

--- a/demo/talk_to_sambanova/requirements.txt
+++ b/demo/talk_to_sambanova/requirements.txt
@@ -1,4 +1,4 @@
 fastrtc[vad, stt]
 python-dotenv
-openai
+huggingface_hub>=0.29.0
 twilio


### PR DESCRIPTION
Related to https://huggingface.co/spaces/fastrtc/talk-to-sambanova-gradio/discussions/1.

This is a suggestion to use the `huggingface_hub` client instead of openai's one to call Sambanova API. No need to provide the sambanova API endpoint anymore. Also, one can use the HF model id and easily switch between providers  (currently 7 providers on https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct, user can select based on speed/cost trade-off).

More advanced suggestion would be to set a `HF_TOKEN` Space secret instead and instantiate the client like this:

```py
client = huggingface_hub.InferenceClient(
    provider="sambanova",
)
```

This will provide HF routing => easier to switch between providers while keeping billing in a single place.

---

To reply to comments:

> I tested this locally and I'm getting this error:
> ```
> fastrtc.utils.WebRTCError: Model meta-llama/Llama-3.2-3B-Instruct is not supported with Sambanova for task conversational.
> ```

@abidlabs Can you retry with latest `huggingface_hub` version? I pinned it in my PR to be sure. 

> I originally saw a bit more latency with going through HF first which is why I originally did not use Inference Client. I will test again and if it's negligible overhead I will switch over!

@freddyaboulton I would be interested if you have some numbers around this (I never benchmarked it myself).
Note that if you use `InferenceClient` with a Sambanova API key directly, you won't be routed through HF. Though I still think in a demo it'd be best in order to showcase how to switch between providers.

> Also please move the PR over to the repo (https://github.com/freddyaboulton/fastrtc/tree/main/demo/talk_to_sambanova) everything gets synched here from there

Done! :heavy_check_mark: 

---

**Note:** I also removed a `raise WebRTCError("test")` that was in the code, making the app fail. 