### PR TITLE
Tidy up connection logic

### DIFF
--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -286,8 +286,7 @@ class WebRTCConnectionMixin:
 
         # handle offer
         await pc.setRemoteDescription(offer)
-        task = asyncio.create_task(self.connection_timeout(pc, body["webrtc_id"], 30))
-        task.add_done_callback(lambda _: print("connection timeout!"))
+        asyncio.create_task(self.connection_timeout(pc, body["webrtc_id"], 30))
         # send answer
         answer = await pc.createAnswer()
         await pc.setLocalDescription(answer)  # type: ignore

--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -197,6 +197,7 @@ class WebRTCConnectionMixin:
                         conn.stop()
                 self.pcs.discard(pc)
             if pc.connectionState == "connected":
+                self.connection_timeouts[body["webrtc_id"]].set()
                 if self.time_limit is not None:
                     asyncio.create_task(self.wait_for_time_limit(pc, self.time_limit))
 

--- a/demo/moonshine_live/app.py
+++ b/demo/moonshine_live/app.py
@@ -1,16 +1,17 @@
+from functools import lru_cache
+from typing import Generator, Literal
+
+import gradio as gr
+import numpy as np
 from fastrtc import (
-    Stream,
     AdditionalOutputs,
-    audio_to_float32,
     ReplyOnPause,
+    Stream,
+    audio_to_float32,
     get_twilio_turn_credentials,
 )
-from functools import lru_cache
-import gradio as gr
-from typing import Generator, Literal
-from numpy.typing import NDArray
-import numpy as np
 from moonshine_onnx import MoonshineOnnxModel, load_tokenizer
+from numpy.typing import NDArray
 
 
 @lru_cache(maxsize=None)

--- a/docs/userguide/api.md
+++ b/docs/userguide/api.md
@@ -109,7 +109,7 @@ async def stream_updates(webrtc_id: str):
 
 ### Handling Errors
 
-When connecting via `WebRTC`, the server will respond to the `/webrtc/offer` route with a JSON response. If there are too many connections, the server will respond with a 429 error.
+When connecting via `WebRTC`, the server will respond to the `/webrtc/offer` route with a JSON response. If there are too many connections, the server will respond with a 200 error.
 
 ```json
 {
@@ -122,6 +122,8 @@ When connecting via `WebRTC`, the server will respond to the `/webrtc/offer` rou
 
 Over `WebSocket`, the server will send the same message before closing the connection.
 
+!!! tip
+    The server will sends a 200 status code because otherwise the gradio client will not be able to process the json response and display the error.
 
 <style>
 .config-selector {

--- a/frontend/shared/InteractiveAudio.svelte
+++ b/frontend/shared/InteractiveAudio.svelte
@@ -154,6 +154,13 @@
                     _time_limit = null;
                     stop(pc);
                     break;
+                case "failed":
+                    console.info("failed");
+                    stream_state = "closed";
+                    _time_limit = null;
+                    dispatch("error", "Connection failed!");
+                    stop(pc);
+                    break;
                 default:
                     break;
             }
@@ -209,6 +216,7 @@
             })
             .catch(() => {
                 console.info("catching");
+                clearTimeout(timeoutId);
                 stream_state = "closed";
             });
     }

--- a/frontend/shared/StaticAudio.svelte
+++ b/frontend/shared/StaticAudio.svelte
@@ -60,6 +60,11 @@
                         console.info("closed");
                         stop(pc);
                         break;
+                    case "failed":
+                        stream_state = "closed";
+                        dispatch("error", "Connection failed!");
+                        stop(pc);
+                        break;
                     default:
                         break;
                 }

--- a/frontend/shared/StaticVideo.svelte
+++ b/frontend/shared/StaticVideo.svelte
@@ -47,6 +47,11 @@
 				case "disconnected":
 					stop(pc);
 					break;
+				case "failed":
+					stream_state = "closed";
+					dispatch("error", "Connection failed!");
+					stop(pc);
+					break;
 				default:
 					break;
 			}

--- a/frontend/shared/Webcam.svelte
+++ b/frontend/shared/Webcam.svelte
@@ -155,6 +155,12 @@
 						stop(pc);
 						await access_webcam();
 						break;
+					case "failed":
+						stream_state = "closed";
+						_time_limit = null;
+						dispatch("error", "Connection failed!");
+						stop(pc);
+						break;
 					default:
 						break;
 				}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastrtc"
-version = "0.0.7rc4"
+version = "0.0.8"
 description = "The realtime communication library for Python"
 readme = "README.md"
 license = "apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastrtc"
-version = "0.0.6"
+version = "0.0.7rc4"
 description = "The realtime communication library for Python"
 readme = "README.md"
 license = "apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastrtc"
-version = "0.0.8"
+version = "0.0.8post1"
 description = "The realtime communication library for Python"
 readme = "README.md"
 license = "apache-2.0"


### PR DESCRIPTION
- Properly display errors in gradio ui if concurrency limit reached
- If connection fails display a gradio error
- If after 30 seconds the backend can't connect, close the channel. Should prevent phantom connections from hogging up one of the concurrency limits