### PR TITLE
Fix documentation links

### DIFF
--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -1,5 +1,5 @@
 
-Any of the parameters for the `Stream` class can be passed to the [`WebRTC`](../userguide/gradio) component directly.
+Any of the parameters for the `Stream` class can be passed to the [`WebRTC`](userguide/gradio) component directly.
 
 ## Track Constraints
 
@@ -42,7 +42,7 @@ You can configure how the connection is created on the client by passing an `rtc
 See the list of available arguments [here](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#configuration).
 
 !!! warning
-When deploying on a remote server, the `rtc_configuration` parameter must be passed in. See [Deployment](../deployment).
+When deploying on a remote server, the `rtc_configuration` parameter must be passed in. See [Deployment](deployment).
 
 ## Reply on Pause Voice-Activity-Detection
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,7 @@
 When deploying in cloud environments with firewalls (like Hugging Face Spaces, RunPod), your WebRTC connections may be blocked from making direct connections. In these cases, you need a TURN server to relay the audio/video traffic between users. This guide covers different options for setting up FastRTC to connect to a TURN server.
 
 !!! tip
-    The `rtc_configuration` parameter of the `Stream` class also be passed to the [`WebRTC`](../userguide/gradio) component directly if you're building a standalone gradio app.
+    The `rtc_configuration` parameter of the `Stream` class also be passed to the [`WebRTC`](userguide/gradio) component directly if you're building a standalone gradio app.
 
 ## Community Server
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,12 +1,12 @@
 ## Demo does not work when deploying to the cloud
 
-Make sure you are using a TURN server. See [deployment](../deployment).
+Make sure you are using a TURN server. See [deployment](deployment).
 
 ## Recorded input audio sounds muffled during output audio playback
 
 By default, the microphone is [configured](https://github.com/freddyaboulton/gradio-webrtc/blob/903f1f70bd586f638ad3b5a3940c7a8ec70ad1f5/backend/gradio_webrtc/webrtc.py#L575) to do echo cancellation.
 This is what's causing the recorded audio to sound muffled when the streamed audio starts playing.
-You can disable this via the `track_constraints` (see [Advanced Configuration](../advanced-configuration)) with the following code:
+You can disable this via the `track_constraints` (see [Advanced Configuration](advanced-configuration)) with the following code:
 
 ```python
 stream = Stream(

--- a/docs/userguide/api.md
+++ b/docs/userguide/api.md
@@ -45,7 +45,7 @@ Over both WebRTC and WebSocket, the server can send messages of the following fo
 
 - `send_input`: Send any input data for the handler to the server. See [`Additional Inputs`](#additional-inputs) for more details.
 - `fetch_output`: An instance of [`AdditionalOutputs`](#additional-outputs) is sent to the server.
-- `stopword`: The stopword has been detected. See [`ReplyOnStopWords`](../audio/#reply-on-stopwords) for more details.
+- `stopword`: The stopword has been detected. See [`ReplyOnStopWords`](audio.md/#reply-on-stopwords) for more details.
 - `error`: An error occurred. The `data` will be a string containing the error message.
 - `warning`: A warning occurred. The `data` will be a string containing the warning message.
 - `log`: A log message. The `data` will be a string containing the log message.
@@ -85,7 +85,7 @@ The updated data will be passed to the handler on the **next** call.
 
 ### Additional Outputs
 
-The `fetch_output` message is sent to the client whenever an instance of [`AdditionalOutputs`](../streams/#additional-outputs) is available. You can access the latest output data by calling the `fetch_latest_output` method of the `Stream` object. 
+The `fetch_output` message is sent to the client whenever an instance of [`AdditionalOutputs`](streams.md/#additional-outputs) is available. You can access the latest output data by calling the `fetch_latest_output` method of the `Stream` object. 
 
 However, rather than fetching each output manually, a common pattern is to fetch the entire stream of output data by calling the `output_stream` method.
 

--- a/docs/userguide/audio-video.md
+++ b/docs/userguide/audio-video.md
@@ -5,7 +5,7 @@ They are identical to the audio `StreamHandlers` with the addition of `video_rec
 
 Here is an example of the video handling functions for connecting with the Gemini multimodal API. In this case, we simply reflect the webcam feed back to the user but every second we'll send the latest webcam frame (and an additional image component) to the Gemini server.
 
-Please see the "Gemini Audio Video Chat" example in the [cookbook](../../cookbook) for the complete code.
+Please see the "Gemini Audio Video Chat" example in the [cookbook](../cookbook) for the complete code.
 
 ``` python title="Async Gemini Video Handling"
 

--- a/docs/userguide/audio.md
+++ b/docs/userguide/audio.md
@@ -132,12 +132,12 @@ The API is similar to `ReplyOnPause` with the addition of a `stop_words` paramet
     ```
 
     1. The `StreamHandler` class implements three methods: `receive`, `emit` and `copy`. The `receive` method is called when a new frame is received from the client, and the `emit` method returns the next frame to send to the client. The `copy` method is called at the beginning of the stream to ensure each user has a unique stream handler.
-    2. The `emit` method SHOULD NOT block. If a frame is not ready to be sent, the method should return `None`. If you need to wait for a frame, use [`wait_for_item`](../../utils#wait_for_item) from the `utils` module.
+    2. The `emit` method SHOULD NOT block. If a frame is not ready to be sent, the method should return `None`. If you need to wait for a frame, use [`wait_for_item`](../utils.md#wait_for_item) from the `utils` module.
     3. The `shutdown` method is called when the stream is closed. It should be used to clean up any resources.
     4. The `start_up` method is called when the stream is first created. It should be used to initialize any resources. See [Talk To OpenAI](https://huggingface.co/spaces/fastrtc/talk-to-openai-gradio) or [Talk To Gemini](https://huggingface.co/spaces/fastrtc/talk-to-gemini-gradio) for an example of a `StreamHandler` that uses the `start_up` method to connect to an API.    
 === "Notes"
     1. The `StreamHandler` class implements three methods: `receive`, `emit` and `copy`. The `receive` method is called when a new frame is received from the client, and the `emit` method returns the next frame to send to the client. The `copy` method is called at the beginning of the stream to ensure each user has a unique stream handler.
-    2. The `emit` method SHOULD NOT block. If a frame is not ready to be sent, the method should return `None`. If you need to wait for a frame, use [`wait_for_item`](../../utils#wait_for_item) from the `utils` module.
+    2. The `emit` method SHOULD NOT block. If a frame is not ready to be sent, the method should return `None`. If you need to wait for a frame, use [`wait_for_item`](../utils.md#wait_for_item) from the `utils` module.
     3. The `shutdown` method is called when the stream is closed. It should be used to clean up any resources.
     4. The `start_up` method is called when the stream is first created. It should be used to initialize any resources. See [Talk To OpenAI](https://huggingface.co/spaces/fastrtc/talk-to-openai-gradio) or [Talk To Gemini](https://huggingface.co/spaces/fastrtc/talk-to-gemini-gradio) for an example of a `StreamHandler` that uses the `start_up` method to connect to an API.
 
@@ -145,7 +145,7 @@ The API is similar to `ReplyOnPause` with the addition of a `stop_words` paramet
     See this [Talk To Gemini](https://huggingface.co/spaces/fastrtc/talk-to-gemini-gradio) for a complete example of a more complex stream handler.
 
 !!! warning
-    The `emit` method should not block. If you need to wait for a frame, use [`wait_for_item`](../../utils#wait_for_item) from the `utils` module.
+    The `emit` method should not block. If you need to wait for a frame, use [`wait_for_item`](../utils.md#wait_for_item) from the `utils` module.
 
 ## Async Stream Handlers
 

--- a/docs/userguide/streams.md
+++ b/docs/userguide/streams.md
@@ -81,7 +81,7 @@ The `handler` argument is the main argument of the `Stream` object. A handler sh
 
 The `Stream` has three main methods:
 
-- `.ui.launch()`: Launch a built-in UI for easily testing and sharing your stream. Built with [Gradio](https://www.gradio.app/). You can change the UI by setting the `ui` property of the `Stream` object. Also see the [Gradio guide](../gradio.md) for building Gradio apss with fastrtc.
+- `.ui.launch()`: Launch a built-in UI for easily testing and sharing your stream. Built with [Gradio](https://www.gradio.app/). You can change the UI by setting the `ui` property of the `Stream` object. Also see the [Gradio guide](gradio) for building Gradio apss with fastrtc.
 - `.fastphone()`: Get a free temporary phone number to call into your stream. Hugging Face token required.
 - `.mount(app)`: Mount the stream on a [FastAPI](https://fastapi.tiangolo.com/) app. Perfect for integrating with your already existing production system or for building a custom UI.
 
@@ -93,7 +93,7 @@ The `Stream` has three main methods:
 You can add additional inputs to your stream using the `additional_inputs` argument. These inputs will be displayed in the generated Gradio UI and they will be passed to the handler as additional arguments.
 
 !!! tip
-    For audio `StreamHandlers`, please read the special [note](../audio#requesting-inputs) on requesting inputs.
+    For audio `StreamHandlers`, please read the special [note](audio.md#requesting-inputs) on requesting inputs.
 
 In the automatic gradio UI, these inputs will be the same python type corresponding to the Gradio component. In our case, we used a `gr.Slider` as the additional input, so it will be passed as a float. See the [Gradio documentation](https://www.gradio.app/docs/gradio) for a complete list of components and their corresponding types.
 
@@ -216,7 +216,7 @@ This will print out a phone number along with your temporary code you can use to
 
 !!! warning
 
-    See this [section](../audio#telephone-integration) on making sure your stream handler is compatible for telephone usage.
+    See this [section](audio.md#telephone-integration) on making sure your stream handler is compatible for telephone usage.
 
 !!! tip
 

--- a/docs/userguide/video.md
+++ b/docs/userguide/video.md
@@ -2,7 +2,7 @@
 
 ## Input/Output Streaming
 
-We already saw this example in the [Quickstart](../../#quickstart) and the [Core Concepts](../streams) section.
+We already saw this example in the [Quickstart](../#quickstart) and the [Core Concepts](streams) section.
 
 === "Code"
     


### PR DESCRIPTION
Some links in the documentation are broken.
I replaced all the links starting with "../" removing this part.
The links with sections (e.g. streams/#additional-outputs) doesn't seem to be working, I added a ".md" and most of them work now.
The ones that are still not rendering correctly are those marked with "!!! warning" and "!!! tip" [here](https://github.com/freddyaboulton/fastrtc/blob/main/docs/userguide/streams.md#telephone-integration) because they are in a block