### PR TITLE
Fix installation command by quoting package name in pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install fastrtc
 to use built-in pause detection (see [ReplyOnPause](https://fastrtc.org/)), and text to speech (see [Text To Speech](https://fastrtc.org/userguide/audio/#text-to-speech)), install the `vad` and `tts` extras:
 
 ```bash
-pip install fastrtc[vad, tts]
+pip install "fastrtc[vad, tts]"
 ```
 
 ## Key Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ pip install fastrtc
 to use built-in pause detection (see [ReplyOnPause](userguide/audio/#reply-on-pause)), speech-to-text (see [Speech To Text](userguide/audio/#speech-to-text)), and text to speech (see [Text To Speech](userguide/audio/#text-to-speech)), install the `vad`, `stt`, and `tts` extras:
 
 ```bash
-pip install fastrtc[vad, stt, tts]
+pip install "fastrtc[vad, stt, tts]"
 ```
 
 ## Quickstart


### PR DESCRIPTION
Added quotes around fastrtc[vad, tts] to prevent shell misinterpretation and ensure correct installation of extras.

Currently Zsh throws an error:  
```
zsh: no matches found: fastrtc[vad,stt,tts]
```  
