### PR TITLE
Simplify Cloudflare config with new endpoint

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,7 +100,7 @@ turn_key_api_token = os.environ.get("TURN_KEY_API_TOKEN")
 ttl = 86400 # Can modify TTL, here it's set to 24 hours
 
 response = requests.post(
-    f"https://rtc.live.cloudflare.com/v1/turn/keys/{turn_key_id}/credentials/generate",
+    f"https://rtc.live.cloudflare.com/v1/turn/keys/{turn_key_id}/credentials/generate-ice-servers",
     headers={
         "Authorization": f"Bearer {turn_key_api_token}",
         "Content-Type": "application/json",
@@ -108,13 +108,11 @@ response = requests.post(
     json={"ttl": ttl},  
 )
 if response.ok:
-    ice_servers = [response.json()["iceServers"]]
+    rtc_configuration = response.json()
 else:
     raise Exception(
         f"Failed to get TURN credentials: {response.status_code} {response.text}"
     )
-
-rtc_configuration = {"iceServers": ice_servers}
 
 stream = Stream(
     handler=...,


### PR DESCRIPTION
Old instructions will still work, but we now have an endpoint that matches the `RTCPeerConnection` signature exactly.