### PR TITLE
Add Method for loading community Vad Models

### DIFF
--- a/backend/fastrtc/__init__.py
+++ b/backend/fastrtc/__init__.py
@@ -3,7 +3,13 @@ from .credentials import (
     get_turn_credentials,
     get_twilio_turn_credentials,
 )
-from .reply_on_pause import AlgoOptions, ReplyOnPause, SileroVadOptions
+from .pause_detection import (
+    ModelOptions,
+    PauseDetectionModel,
+    SileroVadOptions,
+    get_silero_model,
+)
+from .reply_on_pause import AlgoOptions, ReplyOnPause
 from .reply_on_stopwords import ReplyOnStopWords
 from .speech_to_text import MoonshineSTT, get_stt_model
 from .stream import Stream, UIArgs
@@ -63,4 +69,8 @@ __all__ = [
     "KokoroTTSOptions",
     "wait_for_item",
     "UIArgs",
+    "ModelOptions",
+    "PauseDetectionModel",
+    "get_silero_model",
+    "SileroVadOptions",
 ]

--- a/backend/fastrtc/pause_detection/__init__.py
+++ b/backend/fastrtc/pause_detection/__init__.py
@@ -1,3 +1,10 @@
-from .vad import SileroVADModel, SileroVadOptions
+from .protocol import ModelOptions, PauseDetectionModel
+from .silero import SileroVADModel, SileroVadOptions, get_silero_model
 
-__all__ = ["SileroVADModel", "SileroVadOptions"]
+__all__ = [
+    "SileroVADModel",
+    "SileroVadOptions",
+    "PauseDetectionModel",
+    "ModelOptions",
+    "get_silero_model",
+]

--- a/backend/fastrtc/pause_detection/protocol.py
+++ b/backend/fastrtc/pause_detection/protocol.py
@@ -1,0 +1,20 @@
+from typing import Any, Protocol, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..utils import AudioChunk
+
+ModelOptions: TypeAlias = Any
+
+
+class PauseDetectionModel(Protocol):
+    def vad(
+        self,
+        audio: tuple[int, NDArray[np.int16] | NDArray[np.float32]],
+        options: ModelOptions,
+    ) -> tuple[float, list[AudioChunk]]: ...
+
+    def warmup(
+        self,
+    ) -> None: ...

--- a/docs/vad_gallery.md
+++ b/docs/vad_gallery.md
@@ -1,0 +1,60 @@
+<style>
+.tag-button {
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.2s ease;
+}
+
+.tag-button > code {
+    color: var(--supernova);
+}
+
+.tag-button.active {
+    opacity: 1;
+}
+</style>
+
+A collection of VAD models ready to use with FastRTC. Click on the tags below to find the VAD model you're looking for!
+
+
+<div class="tag-buttons">
+  <button class="tag-button" data-tag="pytorch"><code>pytorch</code></button>
+</div>
+
+<script>
+function filterCards() {
+    const activeButtons = document.querySelectorAll('.tag-button.active');
+    const selectedTags = Array.from(activeButtons).map(button => button.getAttribute('data-tag'));
+    const cards = document.querySelectorAll('.grid.cards > ul > li > p[data-tags]');
+    
+    cards.forEach(card => {
+        const cardTags = card.getAttribute('data-tags').split(',');
+        const shouldShow = selectedTags.length === 0 || selectedTags.some(tag => cardTags.includes(tag));
+        card.parentElement.style.display = shouldShow ? 'block' : 'none';
+    });
+}
+document.querySelectorAll('.tag-button').forEach(button => {
+    button.addEventListener('click', () => {
+        button.classList.toggle('active');
+        filterCards();
+    });
+});
+</script>
+
+
+<div class="grid cards" markdown>
+
+-   :speaking_head:{ .lg .middle }:eyes:{ .lg .middle } __Your VAD Model__
+{: data-tags="pytorch"}
+
+    ---
+
+    Description
+
+    Install Instructions
+
+    Usage
+
+    [:octicons-arrow-right-24: Demo](Your demo here)
+    
+    [:octicons-code-16: Repository](Code here)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Cookbook: cookbook.md
   - Deployment: deployment.md
   - Advanced Configuration: advanced-configuration.md
+  - VAD Gallery: vad_gallery.md
   - Utils: utils.md
   - Frequently Asked Questions: faq.md
 extra_javascript:


### PR DESCRIPTION
Developers can pass a `model: PauseDetectionModel` instance to reply on pause and it will be used for VAD. 

This is the required API:

```python
ModelOptions: TypeAlias = Any


class PauseDetectionModel(Protocol):
    def vad(
        self,
        audio: tuple[int, NDArray[np.int16] | NDArray[np.float32]],
        options: ModelOptions,
    ) -> tuple[float, list[AudioChunk]]: ...

    def warmup(
        self,
    ) -> None: ...
```

Developers can then publish their own pypi packages containing their model loading code (or whatever other method they want to use) and open a PR to the VAD gallery in the docs

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/f508b2e8-f4b9-41a1-9dab-2933a52518e5" />
