### PR TITLE
fix: ensure 'model'  is copied in ReplyOnPause.copy()

### DIFF
--- a/backend/fastrtc/reply_on_pause.py
+++ b/backend/fastrtc/reply_on_pause.py
@@ -112,6 +112,7 @@ class ReplyOnPause(StreamHandler):
             self.output_sample_rate,
             self.output_frame_size,
             self.input_sample_rate,
+            self.model,
         )
 
     def determine_pause(


### PR DESCRIPTION
Fixes a bug where the model parameter was not copied in ReplyOnPause.copy(), ensuring consistency in duplicated instances.