### PR TITLE
Fix outdated import in docs

### DIFF
--- a/docs/userguide/audio.md
+++ b/docs/userguide/audio.md
@@ -150,7 +150,7 @@ The API is similar to `ReplyOnPause` with the addition of a `stop_words` paramet
 === "Code"
     ``` py
     import gradio as gr
-    from gradio_webrtc import WebRTC, StreamHandler
+    from fastrtc import StreamHandler
     from queue import Queue
 
     class EchoHandler(StreamHandler):


### PR DESCRIPTION
Since https://github.com/freddyaboulton/gradio-webrtc redirects to this repo, I assume this is an old import that was forgotten there in the example. Also, the `WebRTC` import wasn't used.