### PR TITLE
Some Video Fixes

### DIFF
--- a/backend/fastrtc/__init__.py
+++ b/backend/fastrtc/__init__.py
@@ -21,6 +21,7 @@ from .tracks import (
     AudioVideoStreamHandler,
     StreamHandler,
     VideoEmitType,
+    VideoStreamHandler,
 )
 from .utils import (
     AdditionalOutputs,
@@ -73,4 +74,5 @@ __all__ = [
     "PauseDetectionModel",
     "get_silero_model",
     "SileroVadOptions",
+    "VideoStreamHandler",
 ]

--- a/backend/fastrtc/stream.py
+++ b/backend/fastrtc/stream.py
@@ -63,6 +63,7 @@ class Stream(WebRTCConnectionMixin):
         additional_inputs: list[Component] | None = None,
         additional_outputs: list[Component] | None = None,
         ui_args: UIArgs | None = None,
+        send_input_on: Literal["submit", "change"] = "change",
     ):
         WebRTCConnectionMixin.__init__(self)
         self.mode = mode
@@ -78,6 +79,7 @@ class Stream(WebRTCConnectionMixin):
         self.additional_input_components = additional_inputs
         self.additional_outputs_handler = additional_outputs_handler
         self.rtc_configuration = rtc_configuration
+        self.send_input_on = send_input_on
         self._ui = self._generate_default_ui(ui_args)
         self._ui.launch = self._wrap_gradio_launch(self._ui.launch)
 
@@ -229,6 +231,7 @@ class Stream(WebRTCConnectionMixin):
                     trigger=button.click,
                     time_limit=self.time_limit,
                     concurrency_limit=self.concurrency_limit,  # type: ignore
+                    send_input_on=self.send_input_on,
                 )
                 if additional_output_components:
                     assert self.additional_outputs_handler
@@ -489,7 +492,9 @@ class Stream(WebRTCConnectionMixin):
                             outputs=additional_output_components,
                         )
         elif self.modality == "audio-video" and self.mode == "send-receive":
-            with gr.Blocks() as demo:
+            css = """.my-group {max-width: 600px !important; max-height: 600 !important;}
+            .my-column {display: flex !important; justify-content: center !important; align-items: center !important};"""
+            with gr.Blocks(css=css) as demo:
                 gr.HTML(
                     f"""
                 <h1 style='text-align: center'>
@@ -506,8 +511,8 @@ class Stream(WebRTCConnectionMixin):
                 """
                     )
                 with gr.Row():
-                    with gr.Column():
-                        with gr.Group():
+                    with gr.Column(elem_classes=["my-column"]):
+                        with gr.Group(elem_classes=["my-group"]):
                             image = WebRTC(
                                 label="Stream",
                                 rtc_configuration=self.rtc_configuration,
@@ -532,6 +537,7 @@ class Stream(WebRTCConnectionMixin):
                         outputs=[image],
                         time_limit=self.time_limit,
                         concurrency_limit=self.concurrency_limit,  # type: ignore
+                        send_input_on=self.send_input_on,
                     )
                     if additional_output_components:
                         assert self.additional_outputs_handler

--- a/backend/fastrtc/stream.py
+++ b/backend/fastrtc/stream.py
@@ -46,6 +46,11 @@ class UIArgs(TypedDict):
     """Color of the pulse animation. Default is var(--color-accent) of the demo theme."""
     icon_radius: NotRequired[int]
     """Border radius of the icon button expressed as a percentage of the button size. Default is 50%."""
+    send_input_on: NotRequired[Literal["submit", "change"]]
+    """When to send the input to the handler. Default is "change".
+    If "submit", the input will be sent when the submit event is triggered by the user.
+    If "change", the input will be sent whenever the user changes the input value.
+    """
 
 
 class Stream(WebRTCConnectionMixin):
@@ -63,7 +68,6 @@ class Stream(WebRTCConnectionMixin):
         additional_inputs: list[Component] | None = None,
         additional_outputs: list[Component] | None = None,
         ui_args: UIArgs | None = None,
-        send_input_on: Literal["submit", "change"] = "change",
     ):
         WebRTCConnectionMixin.__init__(self)
         self.mode = mode
@@ -79,7 +83,6 @@ class Stream(WebRTCConnectionMixin):
         self.additional_input_components = additional_inputs
         self.additional_outputs_handler = additional_outputs_handler
         self.rtc_configuration = rtc_configuration
-        self.send_input_on = send_input_on
         self._ui = self._generate_default_ui(ui_args)
         self._ui.launch = self._wrap_gradio_launch(self._ui.launch)
 
@@ -231,7 +234,7 @@ class Stream(WebRTCConnectionMixin):
                     trigger=button.click,
                     time_limit=self.time_limit,
                     concurrency_limit=self.concurrency_limit,  # type: ignore
-                    send_input_on=self.send_input_on,
+                    send_input_on=ui_args.get("send_input_on", "change"),
                 )
                 if additional_output_components:
                     assert self.additional_outputs_handler
@@ -278,6 +281,7 @@ class Stream(WebRTCConnectionMixin):
                     outputs=[output_video],
                     time_limit=self.time_limit,
                     concurrency_limit=self.concurrency_limit,  # type: ignore
+                    send_input_on=ui_args.get("send_input_on", "change"),
                 )
                 if additional_output_components:
                     assert self.additional_outputs_handler
@@ -328,6 +332,7 @@ class Stream(WebRTCConnectionMixin):
                     outputs=[image],
                     time_limit=self.time_limit,
                     concurrency_limit=self.concurrency_limit,  # type: ignore
+                    send_input_on=ui_args.get("send_input_on", "change"),
                 )
                 if additional_output_components:
                     assert self.additional_outputs_handler
@@ -380,6 +385,7 @@ class Stream(WebRTCConnectionMixin):
                     trigger=button.click,
                     time_limit=self.time_limit,
                     concurrency_limit=self.concurrency_limit,  # type: ignore
+                    send_input_on=ui_args.get("send_input_on", "change"),
                 )
                 if additional_output_components:
                     assert self.additional_outputs_handler
@@ -431,6 +437,7 @@ class Stream(WebRTCConnectionMixin):
                     outputs=[image],
                     time_limit=self.time_limit,
                     concurrency_limit=self.concurrency_limit,  # type: ignore
+                    send_input_on=ui_args.get("send_input_on", "change"),
                 )
                 if additional_output_components:
                     assert self.additional_outputs_handler
@@ -483,6 +490,7 @@ class Stream(WebRTCConnectionMixin):
                         outputs=[image],
                         time_limit=self.time_limit,
                         concurrency_limit=self.concurrency_limit,  # type: ignore
+                        send_input_on=ui_args.get("send_input_on", "change"),
                     )
                     if additional_output_components:
                         assert self.additional_outputs_handler
@@ -537,7 +545,7 @@ class Stream(WebRTCConnectionMixin):
                         outputs=[image],
                         time_limit=self.time_limit,
                         concurrency_limit=self.concurrency_limit,  # type: ignore
-                        send_input_on=self.send_input_on,
+                        send_input_on=ui_args.get("send_input_on", "change"),
                     )
                     if additional_output_components:
                         assert self.additional_outputs_handler

--- a/backend/fastrtc/tracks.py
+++ b/backend/fastrtc/tracks.py
@@ -171,9 +171,7 @@ class VideoCallback(VideoStreamTrack):
                 return frame
 
             args = self.add_frame_to_payload(cast(list, self.latest_args), frame_array)
-            print("running event handler", self.event_handler)
             array, outputs = split_output(self.event_handler(*args))
-            print("got output")
             if (
                 isinstance(outputs, AdditionalOutputs)
                 and self.set_additional_outputs

--- a/backend/fastrtc/webrtc.py
+++ b/backend/fastrtc/webrtc.py
@@ -263,6 +263,7 @@ class WebRTC(Component, WebRTCConnectionMixin):
         concurrency_id: str | None = None,
         time_limit: float | None = None,
         trigger: Callable | None = None,
+        send_input_on: Literal["submit", "change"] = "change",
     ):
         from gradio.blocks import Block
 
@@ -304,7 +305,7 @@ class WebRTC(Component, WebRTCConnectionMixin):
                     "In the webrtc stream event, the only output component must be the WebRTC component."
                 )
             for input_component in inputs[1:]:  # type: ignore
-                if hasattr(input_component, "change"):
+                if hasattr(input_component, "change") and send_input_on == "change":
                     input_component.change(  # type: ignore
                         self.set_input,
                         inputs=inputs,
@@ -313,6 +314,13 @@ class WebRTC(Component, WebRTCConnectionMixin):
                         concurrency_limit=None,
                         time_limit=None,
                         js=js,
+                    )
+                if hasattr(input_component, "submit") and send_input_on == "submit":
+                    input_component.submit(  # type: ignore
+                        self.set_input,
+                        inputs=inputs,
+                        outputs=None,
+                        concurrency_id=concurrency_id,
                     )
             return self.tick(  # type: ignore
                 self.set_input,

--- a/backend/fastrtc/webrtc.py
+++ b/backend/fastrtc/webrtc.py
@@ -26,6 +26,7 @@ from .tracks import (
     StreamHandlerBase,
     StreamHandlerImpl,
     VideoEventHandler,
+    VideoStreamHandler,
 )
 from .webrtc_connection_mixin import WebRTCConnectionMixin
 
@@ -254,6 +255,7 @@ class WebRTC(Component, WebRTCConnectionMixin):
             | StreamHandlerImpl
             | AudioVideoStreamHandlerImpl
             | VideoEventHandler
+            | VideoStreamHandler
             | None
         ) = None,
         inputs: Block | Sequence[Block] | set[Block] | None = None,

--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -221,8 +221,6 @@ class WebRTCConnectionMixin:
                     handler_ = handler.callable
                     args["fps"] = handler.fps
                     args["skip_frames"] = handler.skip_frames
-                print(f"args: {args}")
-                print(f"handler_: {handler_}")
                 cb = VideoCallback(
                     relay.subscribe(track),
                     event_handler=cast(Callable, handler_),

--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -31,7 +31,9 @@ from fastrtc.tracks import (
     StreamHandlerBase,
     StreamHandlerImpl,
     VideoCallback,
+    VideoEventHandler,
     VideoStreamHandler,
+    VideoStreamHandler_,
 )
 from fastrtc.utils import (
     AdditionalOutputs,
@@ -41,7 +43,7 @@ from fastrtc.utils import (
 
 Track = (
     VideoCallback
-    | VideoStreamHandler
+    | VideoStreamHandler_
     | AudioCallback
     | ServerToClientAudio
     | ServerToClientVideo
@@ -174,6 +176,11 @@ class WebRTCConnectionMixin:
                 handler.video_receive = webrtc_error_handler(handler.video_receive)  # type: ignore
             if hasattr(handler, "video_emit"):
                 handler.video_emit = webrtc_error_handler(handler.video_emit)  # type: ignore
+        elif isinstance(self.event_handler, VideoStreamHandler):
+            self.event_handler.callable = cast(
+                VideoEventHandler, webrtc_error_handler(self.event_handler.callable)
+            )
+            handler = self.event_handler
         else:
             handler = webrtc_error_handler(cast(Callable, self.event_handler))
 
@@ -208,17 +215,27 @@ class WebRTCConnectionMixin:
             handler = self.handlers[body["webrtc_id"]]
 
             if self.modality == "video" and track.kind == "video":
+                args = {}
+                handler_ = handler
+                if isinstance(handler, VideoStreamHandler):
+                    handler_ = handler.callable
+                    args["fps"] = handler.fps
+                    args["skip_frames"] = handler.skip_frames
+                print(f"args: {args}")
+                print(f"handler_: {handler_}")
                 cb = VideoCallback(
                     relay.subscribe(track),
-                    event_handler=cast(Callable, handler),
+                    event_handler=cast(Callable, handler_),
                     set_additional_outputs=set_outputs,
                     mode=cast(Literal["send", "send-receive"], self.mode),
+                    **args,
                 )
             elif self.modality == "audio-video" and track.kind == "video":
-                cb = VideoStreamHandler(
+                cb = VideoStreamHandler_(
                     relay.subscribe(track),
                     event_handler=handler,  # type: ignore
                     set_additional_outputs=set_outputs,
+                    fps=cast(StreamHandlerImpl, handler).fps,
                 )
             elif self.modality in ["audio", "audio-video"] and track.kind == "audio":
                 eh = cast(StreamHandlerImpl, handler)
@@ -245,10 +262,17 @@ class WebRTCConnectionMixin:
 
         if self.mode == "receive":
             if self.modality == "video":
-                cb = ServerToClientVideo(
-                    cast(Callable, self.event_handler),
-                    set_additional_outputs=set_outputs,
-                )
+                if isinstance(self.event_handler, VideoStreamHandler):
+                    cb = ServerToClientVideo(
+                        cast(Callable, self.event_handler.callable),
+                        set_additional_outputs=set_outputs,
+                        fps=self.event_handler.fps,
+                    )
+                else:
+                    cb = ServerToClientVideo(
+                        cast(Callable, self.event_handler),
+                        set_additional_outputs=set_outputs,
+                    )
             elif self.modality == "audio":
                 cb = ServerToClientAudio(
                     cast(Callable, self.event_handler),

--- a/docs/userguide/video.md
+++ b/docs/userguide/video.md
@@ -70,14 +70,14 @@ from fastrtc import Stream, VideoStreamHandler
 
 
 def process_image(image):
-    # time.sleep(
-    #     0.2
-    # )  # Simulating 200ms processing time per frame; input arrives faster (30 FPS).
+    time.sleep(
+        0.2
+    )  # Simulating 200ms processing time per frame; input arrives faster (30 FPS).
     return np.flip(image, axis=0)
 
 
 stream = Stream(
-    handler=VideoStreamHandler(process_image, skip_frames=False),
+    handler=VideoStreamHandler(process_image, skip_frames=True),
     modality="video",
     mode="send-receive",
 )

--- a/docs/userguide/video.md
+++ b/docs/userguide/video.md
@@ -55,3 +55,73 @@ and set the `mode="receive"` in the `WebRTC` component.
         mode="receive"
     )
     ```
+
+## Skipping Frames
+
+If your event handler is not quite real-time yet, then the output feed will look very laggy.
+
+To fix this, you can set the `skip_frames` parameter to `True`. This will skip the frames that are received while the event handler is still running.
+
+``` py title="Skipping Frames"
+import time
+
+import numpy as np
+from fastrtc import Stream, VideoStreamHandler
+
+
+def process_image(image):
+    # time.sleep(
+    #     0.2
+    # )  # Simulating 200ms processing time per frame; input arrives faster (30 FPS).
+    return np.flip(image, axis=0)
+
+
+stream = Stream(
+    handler=VideoStreamHandler(process_image, skip_frames=False),
+    modality="video",
+    mode="send-receive",
+)
+
+stream.ui.launch()
+```
+
+## Setting the Output Frame Rate
+
+You can set the output frame rate by setting the `fps` parameter in the `VideoStreamHandler`.
+
+``` py title="Setting the Output Frame Rate"
+def generation():
+    url = "https://github.com/user-attachments/assets/9636dc97-4fee-46bb-abb8-b92e69c08c71"
+    cap = cv2.VideoCapture(url)
+    iterating = True
+
+    # FPS calculation variables
+    frame_count = 0
+    start_time = time.time()
+    fps = 0
+
+    while iterating:
+        iterating, frame = cap.read()
+
+        # Calculate and print FPS
+        frame_count += 1
+        elapsed_time = time.time() - start_time
+        if elapsed_time >= 1.0:  # Update FPS every second
+            fps = frame_count / elapsed_time
+            yield frame, AdditionalOutputs(fps)
+            frame_count = 0
+            start_time = time.time()
+        else:
+            yield frame
+
+
+stream = Stream(
+    handler=VideoStreamHandler(generation, fps=60),
+    modality="video",
+    mode="receive",
+    additional_outputs=[gr.Number(label="FPS")],
+    additional_outputs_handler=lambda prev, cur: cur,
+)
+
+stream.ui.launch()
+```


### PR DESCRIPTION
Lets Developers control the Frame Rate
Lets developers skip intermediate frames if the handler is not real time
Lets developers control when the input data is sent over in the gradio ui via send_input_on key in ui_args. Can also set directly in stream event.

Closes #152 

