### PR TITLE
Remove twice instantiated event

### DIFF
--- a/demo/gemini_audio_video/app.py
+++ b/demo/gemini_audio_video/app.py
@@ -49,7 +49,6 @@ class GeminiHandler(AsyncAudioVideoStreamHandler):
         )
         self.audio_queue = asyncio.Queue()
         self.video_queue = asyncio.Queue()
-        self.quit = asyncio.Event()
         self.session = None
         self.last_frame_time = 0
         self.quit = asyncio.Event()


### PR DESCRIPTION
The asyncio.Event() self.quit is set twice in the __init__(), lines 52 and 55. This commit removes one of them.