### PR TITLE
Add get_context function that can be used to retrieve the webrtc id

### DIFF
--- a/backend/fastrtc/__init__.py
+++ b/backend/fastrtc/__init__.py
@@ -34,6 +34,7 @@ from .utils import (
     audio_to_file,
     audio_to_float32,
     audio_to_int16,
+    get_current_context,
     wait_for_item,
 )
 from .webrtc import (
@@ -77,4 +78,5 @@ __all__ = [
     "SileroVadOptions",
     "VideoStreamHandler",
     "CloseStream",
+    "get_current_context",
 ]

--- a/backend/fastrtc/utils.py
+++ b/backend/fastrtc/utils.py
@@ -8,6 +8,7 @@ import logging
 import tempfile
 import traceback
 from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any, Callable, Literal, Protocol, TypedDict, cast
 
 import av
@@ -59,6 +60,22 @@ def create_message(
 current_channel: ContextVar[DataChannel | None] = ContextVar(
     "current_channel", default=None
 )
+
+
+@dataclass
+class Context:
+    webrtc_id: str
+
+
+current_context: ContextVar[Context | None] = ContextVar(
+    "current_context", default=None
+)
+
+
+def get_current_context() -> Context:
+    if not (ctx := current_context.get()):
+        raise RuntimeError("No context found")
+    return ctx
 
 
 def _send_log(message: str, type: str) -> None:


### PR DESCRIPTION
Added a get_contex function that returns a Context class. This class right now has one attribute, the current `webrtc_id`. This is useful for performing certain backend actions for each stream (like tracking the number of turns taken, data generated, storing conversation history).


