### PR TITLE
Improve error handling for websockets

### DIFF
--- a/backend/fastrtc/websocket.py
+++ b/backend/fastrtc/websocket.py
@@ -8,6 +8,7 @@ import anyio
 import librosa
 import numpy as np
 from fastapi import WebSocket
+from fastapi.websockets import WebSocketDisconnect, WebSocketState
 
 from .tracks import AsyncStreamHandler, StreamHandlerImpl
 from .utils import AdditionalOutputs, DataChannel, split_output
@@ -97,9 +98,15 @@ class WebSocketHandler:
         else:
             start_up = anyio.to_thread.run_sync(self.stream_handler.start_up)  # type: ignore
 
+        was_disconnected = False
+
         self.start_up_task = asyncio.create_task(start_up)
         try:
             while not self.quit.is_set():
+                if websocket.application_state != WebSocketState.CONNECTED:
+                    was_disconnected = True
+                    break
+
                 message = await websocket.receive_json()
 
                 if message["event"] == "media":
@@ -117,15 +124,23 @@ class WebSocketHandler:
                             target_sr=self.stream_handler.input_sample_rate,
                         )
                         audio_array = (audio_array * 32768).astype(np.int16)
-                    if isinstance(self.stream_handler, AsyncStreamHandler):
-                        await self.stream_handler.receive(
-                            (self.stream_handler.input_sample_rate, audio_array)
-                        )
-                    else:
-                        await run_sync(
-                            self.stream_handler.receive,
-                            (self.stream_handler.input_sample_rate, audio_array),
-                        )
+
+                    try:
+                        if isinstance(self.stream_handler, AsyncStreamHandler):
+                            await self.stream_handler.receive(
+                                (self.stream_handler.input_sample_rate, audio_array)
+                            )
+                        else:
+                            await run_sync(
+                                self.stream_handler.receive,
+                                (self.stream_handler.input_sample_rate, audio_array),
+                            )
+                    except Exception as e:
+                        print(e)
+                        import traceback
+
+                        traceback.print_exc()
+                        logger.debug("Error in websocket handler %s", e)
 
                 elif message["event"] == "start":
                     if self.stream_handler.phone_mode:
@@ -142,13 +157,10 @@ class WebSocketHandler:
                     return
                 elif message["event"] == "ping":
                     await websocket.send_json({"event": "pong"})
-
-        except Exception as e:
-            print(e)
-            import traceback
-
-            traceback.print_exc()
-            logger.debug("Error in websocket handler %s", e)
+        except WebSocketDisconnect:
+            # Surprisingly, this leaves `websocket.application_state` as CONNECTED
+            # in the `finally` block, so we use this variable
+            was_disconnected = True
         finally:
             if self._emit_task:
                 self._emit_task.cancel()
@@ -156,7 +168,9 @@ class WebSocketHandler:
                 self._emit_to_queue_task.cancel()
             if self.start_up_task:
                 self.start_up_task.cancel()
-            await websocket.close()
+
+            if not was_disconnected:
+                await websocket.close()
 
     async def _emit_to_queue(self):
         try:

--- a/backend/fastrtc/websocket.py
+++ b/backend/fastrtc/websocket.py
@@ -153,8 +153,7 @@ class WebSocketHandler:
                     await self.set_handler(self.stream_id, self)
                 elif message["event"] == "stop":
                     self.quit.set()
-                    self.clean_up(cast(str, self.stream_id))
-                    return
+                    return  # Still runs the `finally` block
                 elif message["event"] == "ping":
                     await websocket.send_json({"event": "pong"})
         except WebSocketDisconnect:
@@ -171,6 +170,8 @@ class WebSocketHandler:
 
             if not was_disconnected:
                 await websocket.close()
+
+            self.clean_up(cast(str, self.stream_id))
 
     async def _emit_to_queue(self):
         try:


### PR DESCRIPTION
When running a FastAPI server over websockets, I was getting this message when the client disconnected:

```
ERROR   Exception in ASGI application
Traceback (most recent call last):
  File "[project path]/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 243, in run_asgi
    result = await self.app(self.scope, self.asgi_receive, self.asgi_send)  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[project path]/.venv/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[project path]/.venv/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 152, in __call__
    await self.app(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/routing.py", line 362, in handle
    await self.app(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/routing.py", line 95, in app
    await wrap_app_handling_exceptions(app, session)(scope, receive, send)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/routing.py", line 93, in app
    await func(session)
  File "[project path]/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 383, in app
    await dependant.call(**solved_result.values)
  File "/Users/vaclav/prog/fastrtc/backend/fastrtc/stream.py", line 646, in websocket_offer
    await ws.handle_websocket(websocket)
  File "/Users/vaclav/prog/fastrtc/backend/fastrtc/websocket.py", line 173, in handle_websocket
    await websocket.close()
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/websockets.py", line 180, in close
    await self.send({"type": "websocket.close", "code": code, "reason": reason or ""})
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/websockets.py", line 85, in send
    await self._send(message)
  File "[project path]/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 39, in sender
    await send(message)
  File "[project path]/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 359, in asgi_send
    raise RuntimeError(msg % message_type)
RuntimeError: Unexpected ASGI message 'websocket.close', after sending 'websocket.close' or response already completed.
```

It was caused by the `finally` block trying to close a websocket that was already closed. This solves the issue by explicitly remembering when `WebSocketDisconnect` was raised.

It also fixes a bug that would occur when the server replied with the ` {"status":"failed","meta": {"error":"concurrency_limit_reached","limit":1}}`. It would end up shooting itself in the foot because of [this part](https://github.com/freddyaboulton/fastrtc/blob/7692ffad005e31305494e9b50150c58d86835c8d/backend/fastrtc/stream.py#L630). Then `websocket.receive_json()` will raise a `RuntimeError` (not a `WebSocketDisconnect`, interestingly) if the socket is not in the `CONNECTED` state. This adds a check for the `CONNECTED` state right before.