### PR TITLE
Allow extra tracks (#231)

### DIFF
--- a/backend/fastrtc/stream.py
+++ b/backend/fastrtc/stream.py
@@ -65,6 +65,7 @@ class Stream(WebRTCConnectionMixin):
         modality: Literal["video", "audio", "audio-video"] = "video",
         concurrency_limit: int | None | Literal["default"] = "default",
         time_limit: float | None = None,
+        allow_extra_tracks: bool = False,
         rtp_params: dict[str, Any] | None = None,
         rtc_configuration: dict[str, Any] | None = None,
         track_constraints: dict[str, Any] | None = None,
@@ -85,6 +86,7 @@ class Stream(WebRTCConnectionMixin):
             int | Literal["default"] | None, concurrency_limit
         )
         self.time_limit = time_limit
+        self.allow_extra_tracks = allow_extra_tracks
         self.additional_output_components = additional_outputs
         self.additional_input_components = additional_inputs
         self.additional_outputs_handler = additional_outputs_handler

--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -81,6 +81,7 @@ class WebRTCConnectionMixin:
         self.time_limit: float | None
         self.modality: Literal["video", "audio", "audio-video"]
         self.mode: Literal["send", "receive", "send-receive"]
+        self.allow_extra_tracks: bool
 
     @staticmethod
     async def wait_for_time_limit(pc: RTCPeerConnection, time_limit: float):
@@ -329,6 +330,8 @@ class WebRTCConnectionMixin:
                 if self.modality not in ["video", "audio", "audio-video"]:
                     msg = "Modality must be either video, audio, or audio-video"
                 else:
+                    if self.allow_extra_tracks:
+                        return
                     msg = f"Unsupported track kind '{track.kind}' for modality '{self.modality}'"
                 raise ValueError(msg)
             if body["webrtc_id"] not in self.connections:


### PR DESCRIPTION
Fixes #231

Tested by modifying ``demo/object_detection`` to include an audio track. Default behavior:

```
ValueError: Unsupported track kind 'audio' for modality 'video'
```

with ``allow_extra_tracks=True`` it works as intended. I will add a unit test as part of #239.