### PR TITLE
Fix bug where additional outputs where not fetched immediately on subsequent connections

### DIFF
--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -133,7 +133,7 @@ class WebRTCConnectionMixin:
         outputs = self.additional_outputs[webrtc_id]
         while not outputs.quit.is_set():
             try:
-                yield await asyncio.wait_for(outputs.queue.get(), 10)
+                yield await asyncio.wait_for(outputs.queue.get(), 0.1)
             except (asyncio.TimeoutError, TimeoutError):
                 logger.debug("Timeout waiting for output")
 


### PR DESCRIPTION
Closes #252 

The issue is that we wait for 10 seconds for the next additional output. So if the concurrency_limit is 1 (default), the next connection will wait ~10 seconds for the previous one to finish and display the `queue 1/1` message.

https://github.com/user-attachments/assets/e4d23a7e-0186-4021-aac7-1d4c2bc2733f

