### PR TITLE
Add started_talking log message in ReplyOnPause and in api.md

### DIFF
--- a/backend/fastrtc/reply_on_pause.py
+++ b/backend/fastrtc/reply_on_pause.py
@@ -209,6 +209,7 @@ class ReplyOnPause(StreamHandler):
             ):
                 state.started_talking = True
                 logger.debug("Started talking")
+                self.send_message_sync(create_message("log", "started_talking"))
             if state.started_talking:
                 if state.stream is None:
                     state.stream = audio

--- a/docs/userguide/api.md
+++ b/docs/userguide/api.md
@@ -55,7 +55,7 @@ The `ReplyOnPause` handler can also send the following `log` messages.
 ```json
 {
     "type": "log",
-    "data": "pause_detected" | "response_starting"
+    "data": "pause_detected" | "response_starting" | "started_talking"
 }
 ```
 


### PR DESCRIPTION
Hi @freddyaboulton , I need this log event, I want to stop a video player (in the frontend) when the user speaks for example, so this event makes it easy for me to handle that, instead of thresholding the mic video. You can see in the OpenAI realtime API that they have these two events https://platform.openai.com/docs/guides/realtime-vad
input_audio_buffer.speech_started: The start of a speech turn (We don't have this)
input_audio_buffer.speech_stopped: The end of a speech turn (same as pause_detected in FastRTC)